### PR TITLE
Update smoltcp to v0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ volatile-register = "0.2"
 aligned = "0.3"
 stm32f4xx-hal = "0.5"
 
-smoltcp = { version = "0.5.0", default-features = false, features = ["proto-ipv4", "proto-ipv6", "socket-icmp", "socket-udp", "socket-tcp", "log", "verbose"], optional = true }
+smoltcp = { version = "0.6.0", default-features = false, features = ["proto-ipv4", "proto-ipv6", "socket-icmp", "socket-udp", "socket-tcp", "log", "verbose", "ethernet"], optional = true }
 log = { version = "0.4", optional = true }
 
 [features]

--- a/src/rx.rs
+++ b/src/rx.rs
@@ -1,4 +1,4 @@
-use core::ops::Deref;
+use core::ops::{Deref, DerefMut};
 use core::default::Default;
 use stm32f4xx_hal::stm32::ETHERNET_DMA;
 
@@ -148,6 +148,12 @@ impl<'a> Deref for RxPacket<'a> {
     
     fn deref(&self) -> &Self::Target {
         &self.entry.as_slice()[0..self.length]
+    }
+}
+
+impl<'a> DerefMut for RxPacket<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.entry.as_mut_slice()[0..self.length]
     }
 }
 

--- a/src/smoltcp_phy.rs
+++ b/src/smoltcp_phy.rs
@@ -1,5 +1,4 @@
 use core::intrinsics::transmute;
-use core::ops::Deref;
 use smoltcp::Error;
 use smoltcp::time::Instant;
 use smoltcp::phy::{DeviceCapabilities, Device, RxToken, TxToken};
@@ -45,10 +44,10 @@ pub struct EthRxToken<'a> {
 }
 
 impl<'a> RxToken for EthRxToken<'a> {
-    fn consume<R, F>(self, _timestamp: Instant, f: F) -> Result<R, Error>
-        where F: FnOnce(&[u8]) -> Result<R, Error>
+    fn consume<R, F>(mut self, _timestamp: Instant, f: F) -> Result<R, Error>
+        where F: FnOnce(&mut [u8]) -> Result<R, Error>
     {
-        let result = f(self.packet.deref());
+        let result = f(&mut self.packet);
         self.packet.free();
         result
     }


### PR DESCRIPTION
This PR is partially inspired by #5 

Smoltcp v0.5.0 doesn't compile anymore (https://github.com/m-labs/smoltcp/issues/315) on the current rust compiler, so an update is needed to use this crate 

