### PR TITLE
Bump stm32f4xx-hal version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ features = [ "smoltcp-phy", "nucleo-f429zi" ]
 [dependencies]
 volatile-register = "0.2"
 aligned = "0.3"
-stm32f4xx-hal = "0.7"
+stm32f4xx-hal = "0.8"
 
 smoltcp = { version = "0.6.0", default-features = false, features = ["proto-ipv4", "proto-ipv6", "socket-icmp", "socket-udp", "socket-tcp", "log", "verbose", "ethernet"], optional = true }
 log = { version = "0.4", optional = true }


### PR DESCRIPTION
The `stm32f4xx-hal` dependency can be safely bumped without any breaking changes.