### PR TITLE
Allow up to 180 MHz clock for the F4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ fn main() {
     let p = Peripherals::take().unwrap();
 
     let rcc = p.RCC.constrain();
-    // HCLK must be between 25MHz and 168MHz to use the ethernet peripheral
+    // HCLK must be at least 25MHz to use the ethernet peripheral
     let clocks = rcc.cfgr.sysclk(32.mhz()).hclk(32.mhz()).freeze();
 
     let gpioa = p.GPIOA.split();

--- a/examples/ip.rs
+++ b/examples/ip.rs
@@ -62,7 +62,7 @@ fn main() -> ! {
     let mut cp = CorePeripherals::take().unwrap();
 
     let rcc = p.RCC.constrain();
-    // HCLK must be between 25MHz and 168MHz to use the ethernet peripheral
+    // HCLK must be at least 25MHz to use the ethernet peripheral
     let clocks = rcc.cfgr.sysclk(32.mhz()).hclk(32.mhz()).freeze();
 
     setup_systick(&mut cp.SYST);

--- a/examples/pktgen.rs
+++ b/examples/pktgen.rs
@@ -36,7 +36,7 @@ fn main() -> ! {
     let mut cp = CorePeripherals::take().unwrap();
 
     let rcc = p.RCC.constrain();
-    // HCLK must be between 25MHz and 168MHz to use the ethernet peripheral
+    // HCLK must be at least 25MHz to use the ethernet peripheral
     let clocks = rcc.cfgr.sysclk(32.mhz()).hclk(32.mhz()).freeze();
 
     setup_systick(&mut cp.SYST);


### PR DESCRIPTION
The ref. manual (RM0090) is inconsistent here: the table 187 on page
1129 states 180 MHz (to which the chip can be overclocked) while
the register description on page 1197 states 168 MHz.