### PR TITLE
Make the creation of TxRingEntry and RxRingEntry const

### DIFF
--- a/src/desc.rs
+++ b/src/desc.rs
@@ -18,13 +18,17 @@ impl Clone for Descriptor {
 
 impl Default for Descriptor {
     fn default() -> Self {
-        Descriptor {
-            desc: Aligned([0; 4]),
-        }
+        Self::new()
     }
 }
 
 impl Descriptor {
+    pub const fn new() -> Self {
+        Self {
+            desc: Aligned([0; 4]),
+        }
+    }
+
     fn r(&self, n: usize) -> &RO<u32> {
         let ro = &self.desc.deref()[n] as *const _ as *const RO<u32>;
         unsafe { &*ro }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,11 +24,11 @@ mod smi;
 pub use ring::RingEntry;
 mod desc;
 mod rx;
-pub use rx::{RxDescriptor, RxError};
-use rx::{RxPacket, RxRing, RxRingEntry};
+pub use rx::{RxDescriptor, RxError, RxRingEntry};
+use rx::{RxPacket, RxRing};
 mod tx;
-pub use tx::{TxDescriptor, TxError};
-use tx::{TxRing, TxRingEntry};
+use tx::TxRing;
+pub use tx::{TxDescriptor, TxError, TxRingEntry};
 pub mod setup;
 pub use setup::EthPins;
 use setup::{

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -1,7 +1,7 @@
 use aligned::{Aligned, A8};
 use core::ops::{Deref, DerefMut};
 
-use crate::MTU;
+use crate::{RxDescriptor, TxDescriptor, MTU};
 
 pub trait RingDescriptor {
     fn setup(&mut self, buffer: *const u8, len: usize, next: Option<&Self>);
@@ -23,18 +23,34 @@ impl<T: Clone + RingDescriptor> Clone for RingEntry<T> {
 
 impl<T: Clone + RingDescriptor + Default> Default for RingEntry<T> {
     fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<T: Clone + RingDescriptor + Default> RingEntry<T> {
-    pub fn new() -> Self {
         RingEntry {
             desc: Aligned([T::default()]),
             buffer: Aligned([0; MTU]),
         }
     }
+}
 
+impl RingEntry<TxDescriptor> {
+    /// Creates a RingEntry with a TxDescriptor.
+    pub const fn new() -> Self {
+        RingEntry {
+            desc: Aligned([TxDescriptor::new()]),
+            buffer: Aligned([0; MTU]),
+        }
+    }
+}
+
+impl RingEntry<RxDescriptor> {
+    /// Creates a RingEntry with a RxDescriptor.
+    pub const fn new() -> Self {
+        RingEntry {
+            desc: Aligned([RxDescriptor::new()]),
+            buffer: Aligned([0; MTU]),
+        }
+    }
+}
+
+impl<T: Clone + RingDescriptor> RingEntry<T> {
     pub(crate) fn setup(&mut self, next: Option<&Self>) {
         let buffer = self.buffer.as_ptr();
         let len = self.buffer.len();


### PR DESCRIPTION
This allow for people to create `RingEntry` on a const context, which saves a considerable amount of stack during initialization if having them in a `static`.

I also left the non const `Default` implementations for compatibility and also because of https://github.com/rust-lang/rust/issues/49147, which causes the creation of entries a bit cumbersome since `Aligned` isn't `Copy`, so users can use `default` on non const contexts if they want to.

CC @adamgreig 