### PR TITLE
Adding support for STM32F107

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -4,9 +4,15 @@ rustflags = [
   "-C", "link-arg=-Tlink.x",
 ]
 
+[target.thumbv7m-none-eabi]
+runner = 'gdb'
+rustflags = [
+  "-C", "link-arg=-Tlink.x",
+]
+
 [build]
 # Pick ONE of these compilation targets
 # target = "thumbv6m-none-eabi"    # Cortex-M0 and Cortex-M0+
-# target = "thumbv7m-none-eabi"    # Cortex-M3
+target = "thumbv7m-none-eabi"    # Cortex-M3
 # target = "thumbv7em-none-eabi"   # Cortex-M4 and Cortex-M7 (no FPU)
-target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
+# target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,11 @@ features = [ "smoltcp-phy", "stm32f429" ]
 [dependencies]
 volatile-register = "0.2"
 aligned = "0.3"
+panic-rtt-target = { version = "0.1", features = ["cortex-m"] }
+rtt-target = { version = "0.2.0", features = ["cortex-m"] }
+# TODO: Necessary for `freeze_explicit` in `ip-f107` example. Need to address this upstream.
+stm32f1xx-hal = { git = "https://github.com/mitchmindtree/stm32f1xx-hal", branch = "torkel-eth-rebased", optional = true }
+#stm32f1xx-hal = {version = "0.6.1", optional = true}
 stm32f7xx-hal = {version = "0.2.0", optional = true}
 stm32f4xx-hal = {version = "0.8.3", optional = true}
 cortex-m = "0.6.2"
@@ -34,6 +39,8 @@ optional = true
 [features]
 device-selected = []
 fence = []
+
+stm32f107 = ["stm32f1xx-hal/stm32f107", "device-selected"]
 
 stm32f407 = ["stm32f4xx-hal/stm32f407", "device-selected"]
 stm32f417 = ["stm32f4xx-hal/stm32f417", "device-selected"]
@@ -61,7 +68,10 @@ cortex-m = "0.6.2"
 cortex-m-rt = "0.6"
 panic-itm = "0.4"
 cortex-m-semihosting = "0.3.5"
-stm32f4xx-hal = {version = "0.8.3", features = ["rt"] }
+#stm32f1xx-hal = {version = "0.6.1", features = ["rt"] }
+# TODO: Necessary for `freeze_explicit` in `ip-f107` example. Need to address this upstream.
+stm32f1xx-hal = { git = "https://github.com/mitchmindtree/stm32f1xx-hal", branch = "torkel-eth-rebased", features = ["rt"] }
+#stm32f4xx-hal = {version = "0.8.3", features = ["rt"] }
 
 [[example]]
 name = "pktgen"
@@ -73,6 +83,10 @@ required-features = [
     "stm32f429", "smoltcp-phy", "log", "smoltcp/socket-tcp", "smoltcp/socket-icmp",
     "smoltcp/log", "smoltcp/verbose"
 ]
+
+[[example]]
+name = "ip-f107"
+required-features = ["stm32f107", "smoltcp-phy", "log", "smoltcp/socket-tcp"]
 
 [profile.release]
 debug = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,7 @@ volatile-register = "0.2"
 aligned = "0.3"
 panic-rtt-target = { version = "0.1", features = ["cortex-m"] }
 rtt-target = { version = "0.2.0", features = ["cortex-m"] }
-# TODO: Necessary for `freeze_explicit` in `ip-f107` example. Need to address this upstream.
-stm32f1xx-hal = { git = "https://github.com/mitchmindtree/stm32f1xx-hal", branch = "torkel-eth-rebased", optional = true }
-#stm32f1xx-hal = {version = "0.6.1", optional = true}
+stm32f1xx-hal = {version = "0.6.1", optional = true}
 stm32f7xx-hal = {version = "0.2.0", optional = true}
 stm32f4xx-hal = {version = "0.8.3", optional = true}
 cortex-m = "0.6.2"
@@ -68,9 +66,7 @@ cortex-m = "0.6.2"
 cortex-m-rt = "0.6"
 panic-itm = "0.4"
 cortex-m-semihosting = "0.3.5"
-#stm32f1xx-hal = {version = "0.6.1", features = ["rt"] }
-# TODO: Necessary for `freeze_explicit` in `ip-f107` example. Need to address this upstream.
-stm32f1xx-hal = { git = "https://github.com/mitchmindtree/stm32f1xx-hal", branch = "torkel-eth-rebased", features = ["rt"] }
+stm32f1xx-hal = {version = "0.6.1", features = ["rt"] }
 #stm32f4xx-hal = {version = "0.8.3", features = ["rt"] }
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,6 @@ features = [ "smoltcp-phy", "stm32f429" ]
 [dependencies]
 volatile-register = "0.2"
 aligned = "0.3"
-panic-rtt-target = { version = "0.1", features = ["cortex-m"] }
-rtt-target = { version = "0.2.0", features = ["cortex-m"] }
 stm32f1xx-hal = {version = "0.6.1", optional = true}
 stm32f7xx-hal = {version = "0.2.0", optional = true}
 stm32f4xx-hal = {version = "0.8.3", optional = true}
@@ -65,6 +63,8 @@ smoltcp-phy = ["smoltcp"]
 cortex-m = "0.6.2"
 cortex-m-rt = "0.6"
 panic-itm = "0.4"
+panic-rtt-target = { version = "0.1", features = ["cortex-m"] }
+rtt-target = { version = "0.2.0", features = ["cortex-m"] }
 cortex-m-semihosting = "0.3.5"
 stm32f1xx-hal = {version = "0.6.1", features = ["rt"] }
 #stm32f4xx-hal = {version = "0.8.3", features = ["rt"] }

--- a/Embed.toml
+++ b/Embed.toml
@@ -1,0 +1,13 @@
+[default.probe]
+protocol = "Swd"
+
+[default.flashing]
+enabled = true
+
+[default.general]
+chip = "STM32F107RC"
+
+[default.rtt]
+enabled = true
+show_timestamps = true
+timeout = 3000

--- a/examples/ip-f107.rs
+++ b/examples/ip-f107.rs
@@ -53,51 +53,13 @@ fn main() -> ! {
     // merging this.
     rprintln!("Setting up clocks");
 
-    // let clocks = rcc
-    //     .cfgr
-    //     .use_hse(8.mhz())
-    //     .sysclk(72.mhz())
-    //     .hclk(72.mhz())
-    //     .pclk1(36.mhz())
-    //     .freeze(&mut flash.acr);
-
-    let clocks = rcc.cfgr.freeze_explicit(
-        &mut flash.acr,
-        25_000_000,
-        stm32f1xx_hal::stm32::rcc::cfgr2::PREDIV1_A::DIV4,
-        stm32f1xx_hal::stm32::rcc::cfgr2::PREDIV2_A::DIV7,
-        stm32f1xx_hal::stm32::rcc::cfgr2::PLL2MUL_A::MUL16,
-        stm32f1xx_hal::stm32::rcc::cfgr2::PLL3MUL_A::MUL12,
-        stm32f1xx_hal::stm32::rcc::cfgr2::PREDIV1SRC_A::HSE,
-        stm32f1xx_hal::stm32::rcc::cfgr::PLLSRC_A::HSE_DIV_PREDIV,
-        stm32f1xx_hal::stm32::rcc::cfgr::PLLMUL_A::MUL8,
-        stm32f1xx_hal::stm32::flash::acr::LATENCY_A::WS2,
-        stm32f1xx_hal::stm32::rcc::cfgr::HPRE_A::DIV1,
-        stm32f1xx_hal::stm32::rcc::cfgr::SW_A::PLL,
-        stm32f1xx_hal::stm32::rcc::cfgr::PPRE1_A::DIV2,
-        stm32f1xx_hal::stm32::rcc::cfgr::PPRE2_A::DIV1,
-        stm32f1xx_hal::stm32::rcc::cfgr::ADCPRE_A::DIV4,
-        stm32f1xx_hal::stm32::rcc::cfgr::OTGFSPRE_A::DIV1_5,
-    );
-
-    rprintln!("\
-    hclk: {}
-    pclk1: {}
-    pclk2: {}
-    pclk1_tim: {}
-    pclk2_tim: {}
-    sysclk: {}
-    adcclk: {}
-    usbclk_valid: {}",
-        clocks.hclk().0,
-        clocks.pclk1().0,
-        clocks.pclk2().0,
-        clocks.pclk1_tim().0,
-        clocks.pclk2_tim().0,
-        clocks.sysclk().0,
-        clocks.adcclk().0,
-        clocks.usbclk_valid(),
-    );
+    let clocks = rcc
+        .cfgr
+        .use_hse(8.mhz())
+        .sysclk(72.mhz())
+        .hclk(72.mhz())
+        .pclk1(36.mhz())
+        .freeze(&mut flash.acr);
 
     rprintln!("Setting up systick");
     setup_systick(&mut cp.SYST);
@@ -208,8 +170,8 @@ fn main() -> ! {
                 cortex_m::interrupt::free(|cs| {
                     let eth_pending = ETH_PENDING.borrow(cs).borrow_mut();
                     if !*eth_pending {
-                        asm::wfi();
                         // Awaken by interrupt
+                        asm::wfi();
                     }
                 });
             }

--- a/examples/ip-f107.rs
+++ b/examples/ip-f107.rs
@@ -52,7 +52,15 @@ fn main() -> ! {
     // I'm unsure exactly why its necessary, but this should be addressed in stm32f1xx-hal before
     // merging this.
     rprintln!("Setting up clocks");
-    //let clocks = rcc.cfgr.sysclk(50.mhz()).hclk(50.mhz()).freeze(&mut flash.acr);
+
+    // let clocks = rcc
+    //     .cfgr
+    //     .use_hse(8.mhz())
+    //     .sysclk(72.mhz())
+    //     .hclk(72.mhz())
+    //     .pclk1(36.mhz())
+    //     .freeze(&mut flash.acr);
+
     let clocks = rcc.cfgr.freeze_explicit(
         &mut flash.acr,
         25_000_000,
@@ -99,15 +107,15 @@ fn main() -> ! {
     let mut gpiob = p.GPIOB.split(&mut rcc.apb2);
     let mut gpioc = p.GPIOC.split(&mut rcc.apb2);
 
-    let ref_clk = gpioa.pa1.into_open_drain_output(&mut gpioa.crl);
-    let md_io = gpioa.pa2.into_floating_input(&mut gpioa.crl);
+    let ref_clk = gpioa.pa1.into_floating_input(&mut gpioa.crl);
+    let md_io = gpioa.pa2.into_alternate_push_pull(&mut gpioa.crl);
     let crs = gpioa.pa7.into_floating_input(&mut gpioa.crl);
     let md_clk = gpioc.pc1.into_alternate_push_pull(&mut gpioc.crl);
     let tx_en = gpiob.pb11.into_alternate_push_pull(&mut gpiob.crh);
     let tx_d0 = gpiob.pb12.into_alternate_push_pull(&mut gpiob.crh);
     let tx_d1 = gpiob.pb13.into_alternate_push_pull(&mut gpiob.crh);
-    let rx_d0 = gpioc.pc4.into_open_drain_output(&mut gpioc.crl);
-    let rx_d1 = gpioc.pc5.into_open_drain_output(&mut gpioc.crl);
+    let rx_d0 = gpioc.pc4.into_floating_input(&mut gpioc.crl);
+    let rx_d1 = gpioc.pc5.into_floating_input(&mut gpioc.crl);
 
     let eth_pins = EthPins {
         ref_clk,

--- a/examples/ip-f107.rs
+++ b/examples/ip-f107.rs
@@ -44,15 +44,7 @@ fn main() -> ! {
     let mut rcc = p.RCC.constrain();
 
     // HCLK must be at least 25MHz to use the ethernet peripheral
-    //
-    // TODO: `freeze_explicit` method comes from here:
-    //
-    // https://github.com/stm32-rs/stm32f1xx-hal/compare/master...torkeldanielsson:master#diff-c6941ad2425cd611249033bed1925f02R396
-    //
-    // I'm unsure exactly why its necessary, but this should be addressed in stm32f1xx-hal before
-    // merging this.
     rprintln!("Setting up clocks");
-
     let clocks = rcc
         .cfgr
         .use_hse(8.mhz())

--- a/examples/ip-f107.rs
+++ b/examples/ip-f107.rs
@@ -1,0 +1,209 @@
+// A copy of the `ip.rs` example, but for the STM32F107.
+
+#![no_std]
+#![no_main]
+
+use panic_rtt_target as _;
+
+use cortex_m::asm;
+use cortex_m_rt::{entry, exception};
+use stm32_eth::{
+    hal::gpio::GpioExt,
+    hal::rcc::RccExt,
+    stm32::{interrupt, CorePeripherals, Peripherals, SYST},
+};
+
+use core::cell::RefCell;
+use cortex_m::interrupt::Mutex;
+
+use core::fmt::Write;
+
+use smoltcp::iface::{EthernetInterfaceBuilder, NeighborCache};
+use smoltcp::socket::{SocketSet, TcpSocket, TcpSocketBuffer};
+use smoltcp::time::Instant;
+use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr, Ipv4Address};
+use stm32_eth::{Eth, EthPins, PhyAddress, RingEntry};
+
+use stm32f1xx_hal::flash::FlashExt;
+use rtt_target::{rprintln, rtt_init_print};
+
+const SRC_MAC: [u8; 6] = [0x00, 0x00, 0xDE, 0xAD, 0xBE, 0xEF];
+
+static TIME: Mutex<RefCell<u64>> = Mutex::new(RefCell::new(0));
+static ETH_PENDING: Mutex<RefCell<bool>> = Mutex::new(RefCell::new(false));
+
+#[entry]
+fn main() -> ! {
+    rtt_init_print!();
+
+    let p = Peripherals::take().unwrap();
+    let mut cp = CorePeripherals::take().unwrap();
+
+    let mut flash = p.FLASH.constrain();
+    let mut rcc = p.RCC.constrain();
+
+    // HCLK must be at least 25MHz to use the ethernet peripheral
+    //
+    // TODO: `freeze_explicit` method comes from here:
+    //
+    // https://github.com/stm32-rs/stm32f1xx-hal/compare/master...torkeldanielsson:master#diff-c6941ad2425cd611249033bed1925f02R396
+    //
+    // I'm unsure exactly why its necessary, but this should be addressed in stm32f1xx-hal before
+    // merging this.
+    rprintln!("Setting up clocks");
+    // let clocks = rcc.cfgr.sysclk(50.mhz()).hclk(25.mhz()).freeze(&mut flash.acr);
+    let clocks = rcc.cfgr.freeze_explicit(
+        &mut flash.acr,
+        25_000_000,
+        stm32f1xx_hal::stm32::rcc::cfgr2::PREDIV1_A::DIV4,
+        stm32f1xx_hal::stm32::rcc::cfgr2::PREDIV2_A::DIV7,
+        stm32f1xx_hal::stm32::rcc::cfgr2::PLL2MUL_A::MUL16,
+        stm32f1xx_hal::stm32::rcc::cfgr2::PLL3MUL_A::MUL12,
+        stm32f1xx_hal::stm32::rcc::cfgr2::PREDIV1SRC_A::HSE,
+        stm32f1xx_hal::stm32::rcc::cfgr::PLLSRC_A::HSE_DIV_PREDIV,
+        stm32f1xx_hal::stm32::rcc::cfgr::PLLMUL_A::MUL8,
+        stm32f1xx_hal::stm32::flash::acr::LATENCY_A::WS2,
+        stm32f1xx_hal::stm32::rcc::cfgr::HPRE_A::DIV1,
+        stm32f1xx_hal::stm32::rcc::cfgr::SW_A::PLL,
+        stm32f1xx_hal::stm32::rcc::cfgr::PPRE1_A::DIV2,
+        stm32f1xx_hal::stm32::rcc::cfgr::PPRE2_A::DIV1,
+        stm32f1xx_hal::stm32::rcc::cfgr::ADCPRE_A::DIV4,
+        stm32f1xx_hal::stm32::rcc::cfgr::OTGFSPRE_A::DIV1_5,
+    );
+
+    rprintln!("Setting up systick");
+    setup_systick(&mut cp.SYST);
+
+    //writeln!(stdout, "Enabling ethernet...").unwrap();
+    let mut gpioa = p.GPIOA.split(&mut rcc.apb2);
+    let mut gpiob = p.GPIOB.split(&mut rcc.apb2);
+    let mut gpioc = p.GPIOC.split(&mut rcc.apb2);
+
+    let ref_clk = gpioa.pa1.into_open_drain_output(&mut gpioa.crl);
+    let md_io = gpioa.pa2.into_floating_input(&mut gpioa.crl);
+    let crs = gpioa.pa7.into_floating_input(&mut gpioa.crl);
+    let md_clk = gpioc.pc1.into_alternate_push_pull(&mut gpioc.crl);
+    let tx_en = gpiob.pb11.into_alternate_push_pull(&mut gpiob.crh);
+    let tx_d0 = gpiob.pb12.into_alternate_push_pull(&mut gpiob.crh);
+    let tx_d1 = gpiob.pb13.into_alternate_push_pull(&mut gpiob.crh);
+    let rx_d0 = gpioc.pc4.into_open_drain_output(&mut gpioc.crl);
+    let rx_d1 = gpioc.pc5.into_open_drain_output(&mut gpioc.crl);
+
+    let eth_pins = EthPins {
+        ref_clk,
+        md_io,
+        md_clk,
+        crs,
+        tx_en,
+        tx_d0,
+        tx_d1,
+        rx_d0,
+        rx_d1,
+    };
+
+    rprintln!("Constructing `Eth`");
+    let mut rx_ring: [RingEntry<_>; 8] = Default::default();
+    let mut tx_ring: [RingEntry<_>; 2] = Default::default();
+    let mut eth = Eth::new(
+        p.ETHERNET_MAC,
+        p.ETHERNET_DMA,
+        &mut rx_ring[..],
+        &mut tx_ring[..],
+        PhyAddress::_0,
+        clocks,
+        eth_pins,
+    )
+    .unwrap();
+    eth.enable_interrupt();
+
+    rprintln!("Setting up TCP/IP");
+    let local_addr = Ipv4Address::new(10, 101, 0, 1);
+    let ip_addr = IpCidr::new(IpAddress::from(local_addr), 16);
+    let mut ip_addrs = [ip_addr];
+    let mut neighbor_storage = [None; 16];
+    let neighbor_cache = NeighborCache::new(&mut neighbor_storage[..]);
+    let ethernet_addr = EthernetAddress(SRC_MAC);
+    let mut iface = EthernetInterfaceBuilder::new(&mut eth)
+        .ethernet_addr(ethernet_addr)
+        .ip_addrs(&mut ip_addrs[..])
+        .neighbor_cache(neighbor_cache)
+        .finalize();
+
+    let mut server_rx_buffer = [0; 2048];
+    let mut server_tx_buffer = [0; 2048];
+    let server_socket = TcpSocket::new(
+        TcpSocketBuffer::new(&mut server_rx_buffer[..]),
+        TcpSocketBuffer::new(&mut server_tx_buffer[..]),
+    );
+    let mut sockets_storage = [None, None];
+    let mut sockets = SocketSet::new(&mut sockets_storage[..]);
+    let server_handle = sockets.add(server_socket);
+
+    rprintln!("Ready, listening at {}", ip_addr);
+    loop {
+        let time: u64 = cortex_m::interrupt::free(|cs| *TIME.borrow(cs).borrow());
+        cortex_m::interrupt::free(|cs| {
+            let mut eth_pending = ETH_PENDING.borrow(cs).borrow_mut();
+            *eth_pending = false;
+        });
+        match iface.poll(&mut sockets, Instant::from_millis(time as i64)) {
+            Ok(true) => {
+                let mut socket = sockets.get::<TcpSocket>(server_handle);
+                if !socket.is_open() {
+                    socket
+                        .listen(80)
+                        .unwrap_or_else(|e| rprintln!("TCP listen error: {:?}", e));
+                }
+
+                if socket.can_send() {
+                    write!(socket, "hello\n")
+                        .map(|_| {
+                            socket.close();
+                        })
+                        .unwrap_or_else(|e| rprintln!("TCP send error: {:?}", e));
+                }
+            }
+            Ok(false) => {
+                // Sleep if no ethernet work is pending
+                cortex_m::interrupt::free(|cs| {
+                    let eth_pending = ETH_PENDING.borrow(cs).borrow_mut();
+                    if !*eth_pending {
+                        asm::wfi();
+                        // Awaken by interrupt
+                    }
+                });
+            }
+            Err(e) =>
+            // Ignore malformed packets
+            {
+                rprintln!("Error: {:?}", e);
+            }
+        }
+    }
+}
+
+fn setup_systick(syst: &mut SYST) {
+    syst.set_reload(SYST::get_ticks_per_10ms() / 10);
+    syst.enable_counter();
+    syst.enable_interrupt();
+}
+
+#[exception]
+fn SysTick() {
+    cortex_m::interrupt::free(|cs| {
+        let mut time = TIME.borrow(cs).borrow_mut();
+        *time += 1;
+    })
+}
+
+#[interrupt]
+fn ETH() {
+    cortex_m::interrupt::free(|cs| {
+        let mut eth_pending = ETH_PENDING.borrow(cs).borrow_mut();
+        *eth_pending = true;
+    });
+
+    // Clear interrupt flags
+    let p = unsafe { Peripherals::steal() };
+    stm32_eth::eth_interrupt_handler(&p.ETHERNET_DMA);
+}

--- a/memory.x
+++ b/memory.x
@@ -1,3 +1,5 @@
+/* STM32F429 */
+/*
 MEMORY
 {
   FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = 2048K
@@ -6,6 +8,13 @@ MEMORY
   RAM3 (xrw)      : ORIGIN = 0x20020000, LENGTH = 64K
   CCMRAM (rw)     : ORIGIN = 0x10000000, LENGTH = 64K
 }
-
 _stack_start = ORIGIN(RAM) + LENGTH(RAM);
 _heap_size = LENGTH(RAM) - 4K;
+*/
+
+/* STM32F107 */
+MEMORY
+{
+  FLASH : ORIGIN = 0x08000000, LENGTH = 128K
+  RAM : ORIGIN = 0x20000000, LENGTH = 32K
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@ pub use stm32f1xx_hal as hal;
 pub use stm32f1xx_hal::pac as stm32;
 
 use hal::rcc::Clocks;
-use rtt_target::rprintln;
 use stm32::{Interrupt, ETHERNET_DMA, ETHERNET_MAC, NVIC};
 
 pub mod phy;
@@ -147,19 +146,15 @@ impl<'rx, 'tx> Eth<'rx, 'tx> {
             _ => ETH_MACMIIAR_CR_HCLK_DIV_102,
         };
 
-        rprintln!("reset_dma_and_wait");
         self.reset_dma_and_wait();
 
-        rprintln!("set clock range");
         // set clock range in MAC MII address register
         self.eth_mac
             .macmiiar
             .modify(|_, w| unsafe { w.cr().bits(clock_range) });
 
-        rprintln!("Reset PHY");
         self.get_phy().reset().set_autoneg();
 
-        rprintln!("MAC configuration");
         // Configuration Register
         self.eth_mac.maccr.modify(|_, w| {
             // CRC stripping for Type frames. STM32F1xx do not have this bit.
@@ -186,7 +181,6 @@ impl<'rx, 'tx> Eth<'rx, 'tx> {
                 .set_bit()
         });
 
-        rprintln!("MAC frame filter");
         // frame filter register
         self.eth_mac.macffr.modify(|_, w| {
             // Receive All
@@ -197,7 +191,6 @@ impl<'rx, 'tx> Eth<'rx, 'tx> {
                 .set_bit()
         });
 
-        rprintln!("MAC flow control register");
         // Flow Control Register
         self.eth_mac.macfcr.modify(|_, w| {
             // Pause time
@@ -207,7 +200,6 @@ impl<'rx, 'tx> Eth<'rx, 'tx> {
             }
         });
 
-        rprintln!("DMA operation mode");
         // operation mode register
         self.eth_dma.dmaomr.modify(|_, w| {
             // Dropping of TCP/IP checksum error frames disable
@@ -230,7 +222,6 @@ impl<'rx, 'tx> Eth<'rx, 'tx> {
                 .set_bit()
         });
 
-        rprintln!("DMA bus mode");
         // bus mode register
         self.eth_dma.dmabmr.modify(|_, w| unsafe {
             // Rx Tx priority ratio 2:1.
@@ -254,8 +245,6 @@ impl<'rx, 'tx> Eth<'rx, 'tx> {
                 .usp()
                 .set_bit()
         });
-
-        rprintln!("Eth::init end");
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub use stm32f4xx_hal::stm32;
 pub use stm32f1xx_hal as hal;
 /// Re-export
 #[cfg(feature = "stm32f1xx-hal")]
-pub use stm32f1xx_hal::device as stm32;
+pub use stm32f1xx_hal::pac as stm32;
 
 use hal::rcc::Clocks;
 use rtt_target::rprintln;

--- a/src/phy.rs
+++ b/src/phy.rs
@@ -1,9 +1,4 @@
-#[cfg(feature = "stm32f4xx-hal")]
-use stm32f4xx_hal::stm32;
-#[cfg(feature = "stm32f7xx-hal")]
-use stm32f7xx_hal::device as stm32;
-
-use stm32::ethernet_mac::{MACMIIAR, MACMIIDR};
+use crate::stm32::ethernet_mac::{MACMIIAR, MACMIIDR};
 
 use core::option::Option;
 

--- a/src/rx.rs
+++ b/src/rx.rs
@@ -1,9 +1,4 @@
-#[cfg(feature = "stm32f4xx-hal")]
-use stm32f4xx_hal::stm32;
-#[cfg(feature = "stm32f7xx-hal")]
-use stm32f7xx_hal::device as stm32;
-
-use stm32::ETHERNET_DMA;
+use crate::stm32::ETHERNET_DMA;
 
 use core::{
     default::Default,
@@ -237,7 +232,12 @@ impl<'a> RxRing<'a> {
         self.next_entry = 0;
         let ring_ptr = self.entries[0].desc() as *const RxDescriptor;
         // Register RxDescriptor
-        eth_dma.dmardlar.write(|w| w.srl().bits(ring_ptr as u32));
+        eth_dma.dmardlar.write(|w| {
+            // Note: unsafe block required for `stm32f107`.
+            unsafe {
+                w.srl().bits(ring_ptr as u32)
+            }
+        });
 
         // We already have fences in `set_owned`, which is called in `setup`
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -262,28 +262,25 @@ impl_pins!(
 mod stm32f1 {
     use super::*;
     use stm32f1xx_hal::gpio::{
-        gpioa, gpiob, gpioc, gpiod, Alternate, Floating, Input, OpenDrain, Output, PushPull,
+        gpioa, gpiob, gpioc, gpiod, Alternate, Floating, Input, PushPull,
     };
 
     // STM32F1xx's require access to the CRL/CRH registers to change pin mode. As a result, we
     // require that pins are already in the necessary mode before constructing `EthPins` as it
     // would be inconvenient to pass CRL and CRH through to the `AlternateVeryHighSpeed` callsite.
 
-    type PA1 = gpioa::PA1<Output<OpenDrain>>;
-    type PA2 = gpioa::PA2<Input<Floating>>;
-    // TODO CRS_DV - Should this be `Output<OpenDrain>` or is this right??
+    type PA1 = gpioa::PA1<Input<Floating>>;
+    type PA2 = gpioa::PA2<Alternate<PushPull>>;
     type PA7 = gpioa::PA7<Input<Floating>>;
     type PB11 = gpiob::PB11<Alternate<PushPull>>;
     type PB12 = gpiob::PB12<Alternate<PushPull>>;
     type PB13 = gpiob::PB13<Alternate<PushPull>>;
     type PC1 = gpioc::PC1<Alternate<PushPull>>;
-    type PC4 = gpioc::PC4<Output<OpenDrain>>;
-    type PC5 = gpioc::PC5<Output<OpenDrain>>;
-    // TODO CRS_DV - Should this be `Output<OpenDrain>` or is this right??
+    type PC4 = gpioc::PC4<Input<Floating>>;
+    type PC5 = gpioc::PC5<Input<Floating>>;
     type PD8 = gpiod::PD8<Input<Floating>>;
-    type PD9 = gpiod::PD9<Output<OpenDrain>>;
-    type PD10 = gpiod::PD10<Output<OpenDrain>>;
-
+    type PD9 = gpiod::PD9<Input<Floating>>;
+    type PD10 = gpiod::PD10<Input<Floating>>;
 
     unsafe impl RmiiRefClk for PA1 {}
     unsafe impl MDIO for PA2 {}

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -99,6 +99,14 @@ pub(crate) fn setup() {
         let afio = &*crate::stm32::AFIO::ptr();
         let rcc = &*crate::stm32::RCC::ptr();
 
+        // enable AFIO clock
+        rcc.apb2enr.modify(|_, w| w.afioen().set_bit());
+
+        if rcc.ahbenr.read().ethmacen().bit_is_set() {
+            // ethernet controller must be disabled when configuring mapr
+            rcc.ahbenr.modify(|_, w| w.ethmacen().clear_bit());
+        }
+
         // select MII or RMII mode
         // 0 = MII, 1 = RMII
         afio.mapr.modify(|_, w| w.mii_rmii_sel().set_bit());

--- a/src/smi.rs
+++ b/src/smi.rs
@@ -1,9 +1,4 @@
-#[cfg(feature = "stm32f4xx-hal")]
-use stm32f4xx_hal::stm32;
-#[cfg(feature = "stm32f7xx-hal")]
-use stm32f7xx_hal::device as stm32;
-
-use stm32::ethernet_mac::{MACMIIAR, MACMIIDR};
+use crate::stm32::ethernet_mac::{MACMIIAR, MACMIIDR};
 
 /// Station Management Interface
 pub struct SMI<'a> {
@@ -29,15 +24,19 @@ impl<'a> SMI<'a> {
     /// Read an SMI register
     pub fn read(&self, phy: u8, reg: u8) -> u16 {
         self.macmiiar.modify(|_, w| {
-            w.pa()
-                .bits(phy)
-                .mr()
-                .bits(reg)
-                /* Read operation MW=0 */
-                .mw()
-                .clear_bit()
-                .mb()
-                .set_bit()
+            // Note: unsafe block required for `stm32f107`.
+            #[allow(unused_unsafe)]
+            unsafe {
+                w.pa()
+                    .bits(phy)
+                    .mr()
+                    .bits(reg)
+                    /* Read operation MW=0 */
+                    .mw()
+                    .clear_bit()
+                    .mb()
+                    .set_bit()
+            }
         });
         self.wait_ready();
 
@@ -46,22 +45,32 @@ impl<'a> SMI<'a> {
     }
 
     fn write_data(&self, data: u16) {
-        self.macmiidr.write(|w| w.md().bits(data));
+        self.macmiidr.write(|w| {
+            // Note: unsafe block required for `stm32f107`.
+            #[allow(unused_unsafe)]
+            unsafe {
+                w.md().bits(data)
+            }
+        });
     }
 
     /// Write an SMI register
     pub fn write(&self, phy: u8, reg: u8, data: u16) {
         self.write_data(data);
         self.macmiiar.modify(|_, w| {
-            w.pa()
-                .bits(phy)
-                .mr()
-                .bits(reg)
-                /* Write operation MW=1*/
-                .mw()
-                .set_bit()
-                .mb()
-                .set_bit()
+            // Note: unsafe block required for `stm32f107`.
+            #[allow(unused_unsafe)]
+            unsafe {
+                w.pa()
+                    .bits(phy)
+                    .mr()
+                    .bits(reg)
+                    /* Write operation MW=1*/
+                    .mw()
+                    .set_bit()
+                    .mb()
+                    .set_bit()
+            }
         });
         self.wait_ready();
     }


### PR DESCRIPTION
This PR is largely based on @torkeldanielsson's work [here](https://github.com/torkeldanielsson/stm32f107_rust_test) and the related upstream forks.

Currently, this still depends on @torkeldanielsson's [stm32f1xx-hal](https://github.com/stm32-rs/stm32f1xx-hal/compare/master...torkeldanielsson:master#) patch which I've rebased and fixed a couple of compiler errors [here](https://github.com/mitchmindtree/stm32f1xx-hal/tree/torkel-eth-rebased). Specifically, the new ip-f107.rs example uses the `rcc.cfgr.freeze_explicit` method, though admittedly I'm not familiar enough with how stm32 clocks work to know why this is required. @torkeldanielsson maybe you could share your thoughts on this?

As mentioned, a new ip-f107.rs example has been added that is a copy of
the existing ip.rs example. It is currently working nicely locally, my
aliexpress dev board with a DP83848 connected via messy jumper wires
responds to pings in ~0.5ms. Ideally, the two ip examples would be
consolidated and each of the device-specific parts should be feature
gated.

Also, note that the `memory.x` has been modified for the STM32f107 as
the existing seemed to be written specifically for an STM32F4 device.

I've also altered the target in `.cargo/config`. Not sure what the best
approach is for setting this. Perhaps in the readme we should just
ensure that users explicilty specify their `--target` when building
examples?