### PR TITLE
Update smoltcp version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ cortex-m = "0.6.2"
 log = { version = "0.4", optional = true }
 
 [dependencies.smoltcp]
-version = "0.6.0"
+version = "0.7.0"
 default-features = false
 features = ["ethernet", "proto-ipv4"]
 optional = true


### PR DESCRIPTION
This allows users to use the DHCP features that can be found in the `0.7.0` version.