### PR TITLE
Bump stm32f7xx-hal from 0.2.0 to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ features = [ "smoltcp-phy", "stm32f429" ]
 [dependencies]
 volatile-register = "0.2"
 aligned = "0.3"
-stm32f7xx-hal = {version = "0.2.0", optional = true}
+stm32f7xx-hal = {version = "0.5.0", optional = true}
 stm32f4xx-hal = {version = "0.8.3", optional = true}
 cortex-m = "0.6.2"
 log = { version = "0.4", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 pub use stm32f7xx_hal as hal;
 /// Re-export
 #[cfg(feature = "stm32f7xx-hal")]
-pub use stm32f7xx_hal::device as stm32;
+pub use stm32f7xx_hal::pac as stm32;
 
 /// Re-export
 #[cfg(feature = "stm32f4xx-hal")]

--- a/src/phy.rs
+++ b/src/phy.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "stm32f4xx-hal")]
 use stm32f4xx_hal::stm32;
 #[cfg(feature = "stm32f7xx-hal")]
-use stm32f7xx_hal::device as stm32;
+use stm32f7xx_hal::pac as stm32;
 
 use stm32::ethernet_mac::{MACMIIAR, MACMIIDR};
 

--- a/src/rx.rs
+++ b/src/rx.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "stm32f4xx-hal")]
 use stm32f4xx_hal::stm32;
 #[cfg(feature = "stm32f7xx-hal")]
-use stm32f7xx_hal::device as stm32;
+use stm32f7xx_hal::pac as stm32;
 
 use stm32::ETHERNET_DMA;
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -16,7 +16,6 @@ use stm32f4xx_hal::{
 use cortex_m::interrupt;
 #[cfg(feature = "stm32f7xx-hal")]
 use stm32f7xx_hal::{
-    device::{RCC, SYSCFG},
     gpio::{
         gpioa::{PA1, PA2, PA7},
         gpiob::{PB11, PB12, PB13},
@@ -25,6 +24,7 @@ use stm32f7xx_hal::{
         Floating, Input,
         Speed::VeryHigh,
     },
+    pac::{RCC, SYSCFG},
 };
 
 // Enable syscfg and ethernet clocks. Reset the Ethernet MAC.

--- a/src/smi.rs
+++ b/src/smi.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "stm32f4xx-hal")]
 use stm32f4xx_hal::stm32;
 #[cfg(feature = "stm32f7xx-hal")]
-use stm32f7xx_hal::device as stm32;
+use stm32f7xx_hal::pac as stm32;
 
 use stm32::ethernet_mac::{MACMIIAR, MACMIIDR};
 

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "stm32f4xx-hal")]
 use stm32f4xx_hal::stm32;
 #[cfg(feature = "stm32f7xx-hal")]
-use stm32f7xx_hal::device as stm32;
+use stm32f7xx_hal::pac as stm32;
 
 use stm32::ETHERNET_DMA;
 


### PR DESCRIPTION
As mentioned in the https://github.com/stm32-rs/stm32-eth/pull/31, the Hal update broke compatibility by merging the https://github.com/stm32-rs/stm32f7xx-hal/pull/57.

Tested with a STM32F767.