### PR TITLE
Cargo: fix docs.rs build (hopefully)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ travis-ci = { repository = "astro/stm32-eth", branch = "master" }
 maintenance = { status = "experimental" }
 
 [package.metadata.docs.rs]
-features = [ "smi", "smoltcp-phy", "stm32f429" ]
+features = [ "smi", "smoltcp-phy", "stm32f429", "smoltcp/socket-tcp" ]
 
 [dependencies]
 volatile-register = "0.2"


### PR DESCRIPTION
If you enable the socket feature, you must enable at least one of the following features: socket-raw, socket-udp, socket-tcp, socket-icmp, socket-dhcp.