### PR TITLE
Add checksum insertion and offloading

### DIFF
--- a/src/desc.rs
+++ b/src/desc.rs
@@ -5,7 +5,7 @@ use volatile_register::{RO, RW};
 
 #[repr(C)]
 pub struct Descriptor {
-    desc: Aligned<A8, [u32; 4]>,
+    desc: Aligned<A8, [u32; 8]>,
 }
 
 impl Clone for Descriptor {
@@ -25,7 +25,7 @@ impl Default for Descriptor {
 impl Descriptor {
     pub const fn new() -> Self {
         Self {
-            desc: Aligned([0; 4]),
+            desc: Aligned([0; 8]),
         }
     }
 

--- a/src/desc.rs
+++ b/src/desc.rs
@@ -3,9 +3,15 @@ use core::ops::{Deref, DerefMut};
 use aligned::{Aligned, A8};
 use volatile_register::{RO, RW};
 
+#[cfg(not(feature = "stm32f107"))]
+const DESC_SIZE: usize = 8;
+
+#[cfg(feature = "stm32f107")]
+const DESC_SIZE: usize = 4;
+
 #[repr(C)]
 pub struct Descriptor {
-    desc: Aligned<A8, [u32; 8]>,
+    desc: Aligned<A8, [u32; DESC_SIZE]>,
 }
 
 impl Clone for Descriptor {
@@ -25,7 +31,7 @@ impl Default for Descriptor {
 impl Descriptor {
     pub const fn new() -> Self {
         Self {
-            desc: Aligned([0; 8]),
+            desc: Aligned([0; DESC_SIZE]),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,9 @@ pub unsafe fn new_unchecked<'rx, 'tx>(
             // Duplex mode
             .dm()
             .set_bit()
+            // IPv4 checksum offload
+            .ipco()
+            .set_bit()
             // Automatic pad/CRC stripping
             .apcs()
             .set_bit()

--- a/src/smoltcp_phy.rs
+++ b/src/smoltcp_phy.rs
@@ -1,6 +1,6 @@
 use crate::{rx::RxPacket, tx::TxError, EthernetDMA};
 use core::intrinsics::transmute;
-use smoltcp::phy::{Device, DeviceCapabilities, RxToken, TxToken};
+use smoltcp::phy::{ChecksumCapabilities, Device, DeviceCapabilities, RxToken, TxToken};
 use smoltcp::time::Instant;
 use smoltcp::Error;
 
@@ -13,6 +13,7 @@ impl<'a, 'rx, 'tx, 'b> Device<'a> for &'b mut EthernetDMA<'rx, 'tx> {
         let mut caps = DeviceCapabilities::default();
         caps.max_transmission_unit = super::MTU;
         caps.max_burst_size = Some(1);
+        caps.checksum = ChecksumCapabilities::ignored();
         caps
     }
 

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -18,6 +18,9 @@ const TXDESC_0_IC: u32 = 1 << 30;
 const TXDESC_0_FS: u32 = 1 << 28;
 /// Last segment of frame
 const TXDESC_0_LS: u32 = 1 << 29;
+/// Checksum insertion control
+const TXDESC_0_CIC0: u32 = 1 << 23;
+const TXDESC_0_CIC1: u32 = 1 << 22;
 /// Transmit end of ring
 const TXDESC_0_TER: u32 = 1 << 21;
 /// Second address chained
@@ -115,8 +118,15 @@ impl RingDescriptor for TxDescriptor {
     fn setup(&mut self, buffer: *const u8, _len: usize, next: Option<&Self>) {
         // Defer this initialization to this function, so we can have `RingEntry` on bss.
         unsafe {
-            self.desc
-                .write(0, TXDESC_0_TCH | TXDESC_0_IC | TXDESC_0_FS | TXDESC_0_LS);
+            self.desc.write(
+                0,
+                TXDESC_0_TCH
+                    | TXDESC_0_IC
+                    | TXDESC_0_FS
+                    | TXDESC_0_LS
+                    | TXDESC_0_CIC0
+                    | TXDESC_0_CIC1,
+            );
         }
         self.set_buffer1(buffer);
         match next {


### PR DESCRIPTION
The stm32 has a built-in module to automatically handle checksums inside IP headers and TCP, UDP, and ICMP payloads, on both the transmit and receive paths. For reference, the [stm4 manual](https://www.st.com/resource/en/reference_manual/rm0090-stm32f405415-stm32f407417-stm32f427437-and-stm32f429439-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) covers transmitting on pages 1141 and 1172, and receiving on pages 1145 and 1184.

For transmission, this involves setting two CIC bits in the transmit descriptor so that checksums are calculated and inserted. On the receive side, we set a bit in the maccr register, and the error is grouped into the general error summary flag on the receive descriptor.

In my (very rough) profiling, this change resulted in about a 30% speedup at 75 Mbps Tx over doing the checksums in software inside smoltpc.

Looking through some other manuals, this feature appears to be supported in all MCUs that have a hardware ETH controller. For example:

- [stmf1 manual](https://www.st.com/resource/en/reference_manual/rm0008-stm32f101xx-stm32f102xx-stm32f103xx-stm32f105xx-and-stm32f107xx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf), pages 987, 1019, etc.
- [stmf7 manual](https://www.st.com/resource/en/reference_manual/rm0410-stm32f76xxx-and-stm32f77xxx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf), pages 1784, 1816, etc.

Let me know if this would be better done some other way, such as config setting, feature, ...