### PR TITLE
Ensure that packet_id overflow does not panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-No unreleased changes.
+* Ensure `packet_id` overflow does not panic ([#87])
 
 ## [0.5.0](https://github.com/stm32-rs/stm32-eth/tree/v0.5.0)
 ### Changes

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -376,7 +376,7 @@ impl EthernetDMA<'_, '_> {
     /// Get the next packet ID.
     pub fn next_packet_id(&mut self) -> PacketId {
         let id = PacketId(self.packet_id_counter);
-        self.packet_id_counter += 1;
+        self.packet_id_counter = self.packet_id_counter.wrapping_add(1);
         id
     }
 }


### PR DESCRIPTION
# Description
While reading through the PTP implementation I noticed that `next_packet_id` just increments an internal counter with `+=`. This might panic once the `packet_id` reaches `u32::MAX`. I changed this to be a `wrapping_add`.

I briefly checked the code base for usages of `PacketId`s to see if at any place it is assumed that they are unique but did not find any such place. Maybe this should also be made explicit in the docs?

I'm happy about any feedback.

# TODO
1. [ ] Check all usages for if they assume that `packet_id`s are unique.
2. [x] Update CHANGELOG.md