### PR TITLE
fix for PTP IEEE standard number in doc

### DIFF
--- a/src/ptp/mod.rs
+++ b/src/ptp/mod.rs
@@ -16,7 +16,7 @@ pub use subseconds::{Subseconds, NANOS_PER_SECOND, SUBSECONDS_PER_SECOND, SUBSEC
 mod pps_pin;
 pub use pps_pin::PPSPin;
 
-/// Access to the IEEE 1508v2 PTP peripheral present on the ethernet peripheral.
+/// Access to the IEEE 1588v2 PTP peripheral present on the ethernet peripheral.
 ///
 /// On STM32FXXX's, the PTP peripheral has/uses the following important parts:
 /// * HCLK (the chip's high speed clock, configured externally).


### PR DESCRIPTION
I am afraid that the correct IEEE standard number for PTP is IEEE 1588 opposed to 1508. 
[source](https://ieeexplore.ieee.org/document/9120376)