### PR TITLE
Upgrade smoltcp to 0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ defmt = { version = "0.3", optional = true }
 futures = { version = "0.3", default-features = false, features = ["async-await"], optional = true }
 
 [dependencies.smoltcp]
-version = "0.11"
+version = "0.12"
 default-features = false
 optional = true
 
@@ -73,7 +73,7 @@ fugit = "0.3"
 defmt-rtt = "0.4"
 panic-probe = { version = "0.3", features = [ "print-defmt" ] }
 systick-monotonic = "1.0"
-smoltcp = { version = "0.11", features = [ "medium-ethernet", "proto-ipv4", "socket-udp", "socket-tcp", "defmt" ], default-features = false }
+smoltcp = { version = "0.12", features = [ "medium-ethernet", "proto-ipv4", "socket-udp", "socket-tcp", "defmt" ], default-features = false }
 
 [dev-dependencies.rtic]
 package = "cortex-m-rtic"

--- a/examples/smoltcp-timesync/client.rs
+++ b/examples/smoltcp-timesync/client.rs
@@ -269,7 +269,7 @@ mod app {
                     let packet_id = dma.lock(|dma| dma.next_packet_id()).into();
 
                     let mut meta: udp::UdpMetadata = IpEndpoint {
-                        addr: IpAddress::Ipv4(Ipv4Address([10, 0, 0, 1])),
+                        addr: IpAddress::Ipv4(Ipv4Address::new(10, 0, 0, 1)),
                         port: 1337,
                     }
                     .into();

--- a/examples/smoltcp-timesync/server.rs
+++ b/examples/smoltcp-timesync/server.rs
@@ -231,7 +231,7 @@ mod app {
                     let packet_id = dma.lock(|dma| dma.next_packet_id()).into();
 
                     let mut meta: udp::UdpMetadata = IpEndpoint {
-                        addr: IpAddress::Ipv4(Ipv4Address([10, 0, 0, 2])),
+                        addr: IpAddress::Ipv4(Ipv4Address::new(10, 0, 0, 2)),
                         port: 1337,
                     }
                     .into();

--- a/src/dma/smoltcp_phy.rs
+++ b/src/dma/smoltcp_phy.rs
@@ -10,8 +10,14 @@ use smoltcp::time::Instant;
 
 /// Use this Ethernet driver with [smoltcp](https://github.com/smoltcp-rs/smoltcp)
 impl<'a, 'rx, 'tx> Device for &'a mut EthernetDMA<'rx, 'tx> {
-    type RxToken<'token> = EthRxToken<'token, 'rx> where Self: 'token;
-    type TxToken<'token> = EthTxToken<'token, 'tx> where Self: 'token;
+    type RxToken<'token>
+        = EthRxToken<'token, 'rx>
+    where
+        Self: 'token;
+    type TxToken<'token>
+        = EthTxToken<'token, 'tx>
+    where
+        Self: 'token;
 
     fn capabilities(&self) -> DeviceCapabilities {
         let mut caps = DeviceCapabilities::default();
@@ -72,7 +78,7 @@ pub struct EthRxToken<'a, 'rx> {
 impl<'dma, 'rx> RxToken for EthRxToken<'dma, 'rx> {
     fn consume<R, F>(self, f: F) -> R
     where
-        F: FnOnce(&mut [u8]) -> R,
+        F: FnOnce(&[u8]) -> R,
     {
         #[cfg(feature = "ptp")]
         let meta = Some(self.meta.into());
@@ -81,8 +87,8 @@ impl<'dma, 'rx> RxToken for EthRxToken<'dma, 'rx> {
         let meta = None;
 
         // NOTE(unwrap): an `EthRxToken` is only created when `eth.rx_available()`
-        let mut packet = self.rx_ring.recv_next(meta).ok().unwrap();
-        let result = f(&mut packet);
+        let packet = self.rx_ring.recv_next(meta).ok().unwrap();
+        let result = f(&packet);
         packet.free();
         result
     }


### PR DESCRIPTION
# Description
Smoltcp updated to version 0.12.0. Examples fixed correspondingly.

# TODO
1. [ ] Update CHANGELOG.md